### PR TITLE
small typo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
     - deid --help
 
 about:
-  home: https://www.github.com/pydicon/deid
+  home: https://www.github.com/pydicom/deid
   license: MIT
   license_family: OTHER
   license_file: LICENSE


### PR DESCRIPTION
I haven't done a fix like this, but hopefully it should be trivial to not bump a version (and just fix a typo in a link).

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>
